### PR TITLE
On-brand spelling of .NET

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![GitHub license](https://img.shields.io/badge/License-Apache%202-blue.svg)](https://raw.githubusercontent.com/corvus-dotnet/Corvus.Extensions/master/LICENSE)
 [![IMM](https://endimmfuncdev.azurewebsites.net/api/imm/github/corvus-dotnet/Corvus.Extensions/total?cache=false)](https://endimmfuncdev.azurewebsites.net/api/imm/github/corvus-dotnet/Corvus.Extensions/total?cache=false)
 
-This provides a library of useful extensions to dotnet types.
+This provides a library of useful extensions to .NET types.
 
 It is built for netstandard2.0.
 


### PR DESCRIPTION
Fix .NET spelling in readme